### PR TITLE
[codex] Improve school kit page conversion flow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,25 +1,27 @@
 import { GoogleAnalytics } from '@next/third-parties/google';
-import CookieConsentBanner from 'components/layout/cookie-consent';
+import WebVitalsReporter from 'components/analytics/web-vitals';
 import Footer from 'components/layout/footer';
 import Navbar from 'components/layout/navbar';
-import TefaSchoolBanner from 'components/layout/tefa-school-banner';
 import { ensureStartsWith } from 'lib/utils';
+import type { Metadata } from 'next';
 import { Open_Sans } from 'next/font/google';
 import { ReactNode, Suspense } from 'react';
 import './globals.css';
 const { TWITTER_CREATOR, TWITTER_SITE, SITE_NAME } = process.env;
+const googleAnalyticsId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID || 'G-4SWM464SP9';
 const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL
   ? `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`
   : 'http://localhost:3000';
 const twitterCreator = TWITTER_CREATOR ? ensureStartsWith(TWITTER_CREATOR, '@') : undefined;
 const twitterSite = TWITTER_SITE ? ensureStartsWith(TWITTER_SITE, 'https://') : undefined;
+const googleSiteVerification = process.env.GOOGLE_SITE_VERIFICATION;
 const openSans = Open_Sans({
   weight: ['400', '600', '700'],
   subsets: ['latin'],
   style: 'normal',
   display: 'swap'
 });
-export const metadata = {
+export const metadata: Metadata = {
   metadataBase: new URL(baseUrl),
   title: {
     default: SITE_NAME!,
@@ -36,7 +38,12 @@ export const metadata = {
         creator: twitterCreator,
         site: twitterSite
       }
-    })
+    }),
+  ...(googleSiteVerification && {
+    verification: {
+      google: googleSiteVerification
+    }
+  })
 };
 
 export default async function RootLayout({ children }: { children: ReactNode }) {
@@ -49,13 +56,12 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
         />
       </head>
       <body className="flex min-h-svh flex-col bg-neutral-50 text-black selection:bg-teal-300">
-        <GoogleAnalytics gaId="G-4SWM464SP9" />
+        <GoogleAnalytics gaId={googleAnalyticsId} />
+        <WebVitalsReporter />
         <Suspense>
           <Navbar />
-          <TefaSchoolBanner />
           <main className="flex-1">{children}</main>
           <Footer />
-          <CookieConsentBanner />
         </Suspense>
       </body>
     </html>

--- a/app/schools/[slug]/page.tsx
+++ b/app/schools/[slug]/page.tsx
@@ -1,7 +1,7 @@
-import ProductGridItems from 'components/layout/product-grid-items';
 import SchoolRequestActions from 'components/schools/school-request-actions';
 import { getProductsByIds } from 'lib/shopify';
 import { getSchoolBySlug } from 'lib/schools';
+import { ArrowRight } from 'lucide-react';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -9,6 +9,12 @@ import { notFound } from 'next/navigation';
 type SchoolPageParams = {
   params: Promise<{ slug: string }>;
 };
+
+const formatPrice = (amount: string) =>
+  new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD'
+  }).format(Number(amount));
 
 export async function generateMetadata({ params }: SchoolPageParams): Promise<Metadata> {
   const { slug } = await params;
@@ -44,42 +50,140 @@ export default async function SchoolDetailPage({ params }: SchoolPageParams) {
   );
   const products = productIds.length > 0 ? await getProductsByIds(productIds) : [];
   const location = [school.city, school.state].filter(Boolean).join(', ');
+  const isOfficialSchoolKit = school.isFulfilledBySchoolKits;
+  const heroTitle = `${school.name} kits`;
+  const heroDescription = isOfficialSchoolKit
+    ? `We use ${school.name}'s official supply lists, then pack each grade as one kit. Pick your child's grade below.`
+    : `Pick an available grade kit below. You can review the supplies before adding it to your cart.`;
 
   return (
-    <div className="container mx-auto px-4 py-10 sm:px-6 lg:px-8 lg:py-14">
-      <div className="mx-auto max-w-6xl">
-        <Link href="/schools" className="text-sm font-medium text-[#0B80A7] hover:underline">
+    <div className="bg-white">
+      <div className="mx-auto max-w-6xl px-4 py-4 sm:px-6 lg:px-8 lg:py-5">
+        <Link
+          href="/schools"
+          className="inline-flex text-sm font-semibold text-[#0B80A7] hover:underline"
+        >
           Back to school search
         </Link>
+      </div>
 
-        <section className="mt-5 rounded-[2rem] bg-[#F4FDFF] px-6 py-8 sm:px-8 lg:px-10">
-          <div className="max-w-3xl">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-[#0B80A7]">School</p>
-            <div className="mt-3 flex items-start gap-3 sm:items-center sm:gap-4">
+      <section className="border-y border-[#D9EEF4] bg-[#F4FDFF]">
+        <div className="mx-auto grid max-w-6xl gap-5 px-4 py-5 sm:px-6 sm:py-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-start lg:px-8 lg:py-8">
+          <div>
+            <div className="flex items-start gap-3 sm:gap-4">
               {school.logoUrl ? (
                 <img
                   src={school.logoUrl}
                   alt={`${school.name} logo`}
-                  className="h-14 w-14 shrink-0 rounded-full border border-[#D9EEF4] bg-white object-contain p-2 sm:h-20 sm:w-20"
+                  className="h-12 w-12 shrink-0 rounded-lg border border-[#D9EEF4] bg-white object-contain p-1.5 sm:h-16 sm:w-16 sm:p-2"
                 />
               ) : null}
-              <h1 className="min-w-0 break-words text-3xl font-bold leading-tight tracking-tight text-black sm:text-5xl">
-                {school.name}
-              </h1>
+              <div className="min-w-0">
+                <p className="text-[11px] font-bold uppercase text-[#0B80A7] sm:text-xs">
+                  {isOfficialSchoolKit ? 'Fulfilled by School Kits' : 'School kit page'}
+                </p>
+                <h1 className="mt-1.5 break-words text-2xl font-bold leading-tight text-black sm:text-4xl lg:text-[42px]">
+                  {heroTitle}
+                </h1>
+                <p className="mt-2 text-sm font-semibold text-[#315565] sm:text-base">
+                  {location || 'School Kits'}
+                </p>
+              </div>
             </div>
-            <p className="mt-4 text-base leading-7 text-gray-600">{location || 'School Kits'}</p>
-          </div>
-        </section>
 
-        <section className="mt-10">
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-[#315565] sm:text-base sm:leading-7">
+              {heroDescription}
+            </p>
+
+            <p className="mt-4 text-sm font-semibold text-[#102A33]">
+              One kit covers one student for one grade.
+            </p>
+          </div>
+
           {products.length > 0 ? (
-            <ProductGridItems products={products} />
+            <div className="hidden self-start rounded-lg border border-[#B8DDE7] bg-white p-4 shadow-sm sm:p-5 md:block">
+              <p className="text-sm font-bold uppercase text-[#0B80A7]">Ordering note</p>
+              <h2 className="mt-1.5 text-xl font-bold text-black sm:text-2xl">
+                Buying for siblings?
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-gray-600">
+                Add each child&apos;s grade kit to the same cart before checkout.
+              </p>
+              <a
+                href="#grade-kits"
+                className="mt-4 inline-flex w-full items-center justify-center rounded-full bg-[#0B80A7] px-5 py-3 text-sm font-bold text-white transition hover:bg-[#096B8C]"
+              >
+                View grade kits
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </a>
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <div className="mx-auto max-w-6xl px-4 py-7 sm:px-6 lg:px-8 lg:py-9">
+        <section id="grade-kits">
+          <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-2xl font-bold text-black">Choose a grade</h2>
+              <p className="mt-1 text-sm leading-6 text-gray-600">
+                Tap a kit to see the supplies and order.
+              </p>
+            </div>
+          </div>
+
+          {products.length > 0 ? (
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {products.map((product) => {
+                const price = product.priceRange.minVariantPrice.amount;
+                const compareAtPrice = product.compareAtPriceRange?.minVariantPrice?.amount;
+                const isOnSale = compareAtPrice && Number(compareAtPrice) > Number(price);
+
+                return (
+                  <Link
+                    key={product.id}
+                    href={`/product/${product.handle}`}
+                    className="group flex min-h-32 flex-col justify-between rounded-lg border border-[#D9EEF4] bg-white p-4 shadow-sm transition hover:border-[#0B80A7] hover:shadow-md sm:min-h-36 sm:p-5"
+                  >
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        {isOnSale ? (
+                          <p className="mb-2 inline-flex rounded-full bg-[#E6F6FB] px-3 py-1 text-xs font-bold text-[#0B80A7]">
+                            Sale
+                          </p>
+                        ) : null}
+                        <h3 className="text-lg font-bold leading-tight text-black sm:text-xl">
+                          {product.title}
+                        </h3>
+                      </div>
+                      <div className="shrink-0 text-right">
+                        <p className="text-xl font-bold text-[#0B80A7] sm:text-2xl">
+                          {formatPrice(price)}
+                        </p>
+                        {isOnSale ? (
+                          <p className="text-sm text-gray-400 line-through">
+                            {formatPrice(compareAtPrice)}
+                          </p>
+                        ) : null}
+                      </div>
+                    </div>
+                    <div className="mt-5 inline-flex items-center text-sm font-bold text-[#0B80A7]">
+                      Order this kit
+                      <ArrowRight
+                        className="ml-2 h-4 w-4 transition group-hover:translate-x-1"
+                        aria-hidden="true"
+                      />
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
           ) : (
-            <div className="rounded-[1.75rem] border border-dashed border-[#D9EEF4] bg-white px-6 py-10 text-center">
+            <div className="rounded-lg border border-dashed border-[#D9EEF4] bg-white px-6 py-10 text-center">
               <h2 className="text-2xl font-semibold text-black">Kits are not online yet</h2>
               <p className="mx-auto mt-3 max-w-2xl text-sm leading-7 text-gray-600">
-                Kits for this school are not available to order online right now. If you would like this school reviewed,
-                send a quick request below.
+                Kits for this school are not available to order online right now. If you would like
+                this school reviewed, send a quick request below.
               </p>
               <SchoolRequestActions
                 schoolName={school.name}

--- a/components/analytics/web-vitals.tsx
+++ b/components/analytics/web-vitals.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+
+type WebVitalsMetric = {
+  id: string;
+  name: string;
+  value: number;
+  rating?: 'good' | 'needs-improvement' | 'poor';
+  delta?: number;
+  navigationType?: string;
+};
+
+function reportWebVitals(metric: WebVitalsMetric) {
+  window.gtag?.('event', 'web_vital', {
+    event_category: 'Web Vitals',
+    event_label: metric.id,
+    metric_id: metric.id,
+    metric_name: metric.name,
+    metric_rating: metric.rating,
+    metric_value: metric.value,
+    navigation_type: metric.navigationType,
+    page_path: window.location.pathname,
+    value: Math.round(metric.name === 'CLS' ? metric.value * 1000 : metric.value),
+    non_interaction: true
+  });
+}
+
+export default function WebVitalsReporter() {
+  useReportWebVitals(reportWebVitals);
+
+  return null;
+}

--- a/components/cart/add-to-cart.tsx
+++ b/components/cart/add-to-cart.tsx
@@ -6,8 +6,27 @@ import { addItem } from 'components/cart/actions';
 import LoadingDots from 'components/loading-dots';
 import { ProductVariant } from 'lib/shopify/types';
 import { usePathname, useSearchParams } from 'next/navigation';
-import { useActionState, useEffect, useState } from 'react';
+import { useActionState, useEffect, useRef, useState } from 'react';
 import { useFormStatus } from 'react-dom';
+
+type WindowWithGtag = Window & {
+  gtag?: (
+    command: 'event',
+    eventName: string,
+    params?: {
+      currency?: string;
+      value?: number;
+      items?: Array<{
+        item_id: string;
+        item_name: string;
+        item_variant?: string;
+        item_category?: string;
+        price?: number;
+        quantity?: number;
+      }>;
+    }
+  ) => void;
+};
 
 function SubmitButton({
   availableForSale,
@@ -76,6 +95,7 @@ export function AddToCart({
   schoolName?: string;
 }) {
   const [state, formAction] = useActionState(addItem, {});
+  const lastTrackedUpdate = useRef<number | undefined>(undefined);
   const [isSubmittingRequest, setIsSubmittingRequest] = useState(false);
   const [requestSubmitted, setRequestSubmitted] = useState(false);
   const [requestError, setRequestError] = useState('');
@@ -88,13 +108,48 @@ export function AddToCart({
     )
   );
   const selectedVariantId = variant?.id || defaultVariantId;
+  const selectedVariant =
+    variant || variants.find((variant: ProductVariant) => variant.id === defaultVariantId);
   const actionWithVariant = formAction.bind(null, selectedVariantId);
 
   useEffect(() => {
     if (state?.updatedAt) {
       window.dispatchEvent(new CustomEvent('cart:updated', { detail: { open: true } }));
+
+      if (lastTrackedUpdate.current === state.updatedAt) {
+        return;
+      }
+
+      lastTrackedUpdate.current = state.updatedAt;
+
+      const price = Number(selectedVariant?.price.amount ?? 0);
+      const currency = selectedVariant?.price.currencyCode ?? 'USD';
+
+      (window as WindowWithGtag).gtag?.('event', 'add_to_cart', {
+        currency,
+        value: price,
+        items: [
+          {
+            item_id: productHandle,
+            item_name: productTitle,
+            item_variant:
+              selectedVariant?.title === 'Default Title' ? undefined : selectedVariant?.title,
+            item_category: schoolName,
+            price,
+            quantity: 1
+          }
+        ]
+      });
     }
-  }, [state?.updatedAt]);
+  }, [
+    productHandle,
+    productTitle,
+    schoolName,
+    selectedVariant?.price.amount,
+    selectedVariant?.price.currencyCode,
+    selectedVariant?.title,
+    state?.updatedAt
+  ]);
 
   const submitRestockRequest = async () => {
     setIsSubmittingRequest(true);
@@ -146,10 +201,15 @@ export function AddToCart({
             }
           )}
         >
-          {isSubmittingRequest ? 'Sending request...' : requestSubmitted ? 'Request sent' : 'Request more inventory'}
+          {isSubmittingRequest
+            ? 'Sending request...'
+            : requestSubmitted
+            ? 'Request sent'
+            : 'Request more inventory'}
         </button>
         <p className="text-sm leading-6 text-gray-600">
-          Out of stock right now. Send a quick request and we&apos;ll let our team know this kit needs attention.
+          Out of stock right now. Send a quick request and we&apos;ll let our team know this kit
+          needs attention.
         </p>
         {requestError ? <p className="text-sm text-[#B42318]">{requestError}</p> : null}
       </div>

--- a/components/cart/modal.tsx
+++ b/components/cart/modal.tsx
@@ -18,6 +18,28 @@ type MerchandiseSearchParams = {
   [key: string]: string;
 };
 
+type WindowWithGtag = Window & {
+  gtag?: (
+    command: 'event',
+    eventName: string,
+    params?: {
+      currency?: string;
+      value?: number;
+      page_location?: string;
+      event_callback?: () => void;
+      event_timeout?: number;
+      items?: Array<{
+        item_id: string;
+        item_name: string;
+        item_variant?: string;
+        item_category?: string;
+        price?: number;
+        quantity?: number;
+      }>;
+    }
+  ) => void;
+};
+
 export default function CartModal({ cart }: { cart: Cart | undefined }) {
   const [isOpen, setIsOpen] = useState(false);
   const [childNames, setChildNames] = useState<{ [key: string]: string[] }>({});
@@ -40,18 +62,18 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
     window.addEventListener('cart:open', handleCartOpen);
     return () => window.removeEventListener('cart:open', handleCartOpen);
   }, []);
-  
+
   // Handle page visibility changes to ensure clean state when returning from checkout
-  useEffect(() => {    
+  useEffect(() => {
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
         // When returning to the page, ensure cart modal is closed
         setIsOpen(false);
       }
     };
-    
+
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    
+
     return () => {
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
@@ -96,7 +118,7 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
       console.error('Error saving child names to local storage:', error);
     }
 
-     validateChildNames(updatedChildNames);
+    validateChildNames(updatedChildNames);
   }, [localCart?.lines]);
 
   const handleChildNameChange = (lineId: string, index: number, value: string) => {
@@ -118,8 +140,8 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
   };
 
   const validateChildNames = (names: { [key: string]: string[] }) => {
-    const isValid = Object.values(names).every((nameArray) => 
-      nameArray.length > 0 && nameArray.every((name) => name.trim() !== '')
+    const isValid = Object.values(names).every(
+      (nameArray) => nameArray.length > 0 && nameArray.every((name) => name.trim() !== '')
     );
     setIsCheckoutDisabled(!isValid);
   };
@@ -160,20 +182,20 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
       if (localCart && Object.keys(childNames).length > 0) {
         try {
           const notes = prepareShopifyNotes();
-          
+
           // Use the API endpoint instead of server action
           const response = await fetch('/api/cart/notes', {
             method: 'POST',
             headers: {
-              'Content-Type': 'application/json',
+              'Content-Type': 'application/json'
             },
-            body: JSON.stringify({ notes }),
+            body: JSON.stringify({ notes })
           });
-          
+
           if (!response.ok) {
             throw new Error('Failed to update cart notes');
           }
-          
+
           // We don't need to do anything with the result here
           // Just silently update the notes in the background
         } catch (error) {
@@ -193,20 +215,20 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
       alert('Please enter names for all children before proceeding to checkout.');
       return false;
     }
-    
+
     setIsSavingNotes(true);
-    
+
     try {
       const notes = prepareShopifyNotes();
       const result = await updateCartNotes(notes);
-      
+
       if (result.error) {
         console.error('Error updating cart notes:', result.error);
         alert('There was an error updating your cart. Please try again.');
         setIsSavingNotes(false);
         return false;
       }
-      
+
       setIsSavingNotes(false);
       return true;
     } catch (error) {
@@ -216,22 +238,71 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
     }
   };
 
+  const trackBeginCheckout = (checkoutUrl: string) => {
+    if (!localCart || localCart.lines.length === 0) {
+      window.location.href = checkoutUrl;
+      return;
+    }
+
+    const value = Number(localCart.cost.totalAmount.amount);
+    const currency = localCart.cost.totalAmount.currencyCode;
+    const gtag = (window as WindowWithGtag).gtag;
+    let didRedirect = false;
+    const redirectToCheckout = () => {
+      if (didRedirect) {
+        return;
+      }
+
+      didRedirect = true;
+      window.location.href = checkoutUrl;
+    };
+
+    if (!gtag) {
+      redirectToCheckout();
+      return;
+    }
+
+    gtag('event', 'begin_checkout', {
+      currency,
+      value,
+      page_location: window.location.href,
+      event_callback: redirectToCheckout,
+      event_timeout: 800,
+      items: localCart.lines.map((item) => {
+        const quantity = item.quantity;
+        const totalAmount = Number(item.cost.totalAmount.amount);
+        const price = quantity > 0 ? totalAmount / quantity : totalAmount;
+
+        return {
+          item_id: item.merchandise.product.handle || item.merchandise.product.id,
+          item_name: item.merchandise.product.title,
+          item_variant:
+            item.merchandise.title === DEFAULT_OPTION ? undefined : item.merchandise.title,
+          item_category: item.merchandise.product.collection,
+          price,
+          quantity
+        };
+      })
+    });
+
+    window.setTimeout(redirectToCheckout, 900);
+  };
+
   // This function handles the checkout button click
   const handleCheckout = (e: React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();
-    
+
     if (isCheckoutDisabled) {
       alert('Please enter names for all children before proceeding to checkout.');
       return;
     }
-    
+
     // Simply close the cart modal and navigate to the checkout URL
     // The cart notes have already been saved in the background
     setIsOpen(false);
-    
+
     if (localCart?.checkoutUrl) {
-      // For Safari compatibility, use a simple window.location.href
-      window.location.href = localCart.checkoutUrl;
+      trackBeginCheckout(localCart.checkoutUrl);
     }
   };
 
@@ -262,14 +333,14 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
             leaveFrom="translate-x-0"
             leaveTo="translate-x-full"
           >
-            <Dialog.Panel className="fixed bottom-0 right-0 top-0 flex h-full w-full flex-col border-l border-neutral-200 bg-white/80 p-6 text-black backdrop-blur-xl dark:border-neutral-700 dark:bg-black/80 dark:text-white md:w-[390px]">
+            <Dialog.Panel className="fixed bottom-0 right-0 top-0 flex h-full w-full flex-col border-l border-neutral-200 bg-white/80 p-6 text-black backdrop-blur-xl md:w-[390px] dark:border-neutral-700 dark:bg-black/80 dark:text-white">
               <div className="flex items-center justify-between">
                 <p className="text-lg font-semibold">My Cart</p>
                 <button aria-label="Close cart" onClick={closeCart}>
                   <CloseCart />
                 </button>
               </div>
-                {!localCart || localCart.lines.length === 0 ? (
+              {!localCart || localCart.lines.length === 0 ? (
                 <div className="mt-20 flex w-full flex-col items-center justify-center overflow-hidden">
                   <ShoppingCartIcon className="h-16" />
                   <p className="mt-6 text-center text-2xl font-bold">Your cart is empty.</p>
@@ -350,7 +421,9 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
                                 key={`${item.id}-${index}`}
                                 type="text"
                                 value={childNames[item.id]?.[index] || ''}
-                                onChange={(e) => handleChildNameChange(item.id, index, e.target.value)}
+                                onChange={(e) =>
+                                  handleChildNameChange(item.id, index, e.target.value)
+                                }
                                 placeholder={`Child ${index + 1}'s name`}
                                 className="mt-2 w-full rounded-md border border-neutral-200 px-3 py-2 text-sm placeholder-neutral-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-neutral-700 dark:bg-black dark:text-white dark:placeholder-neutral-400"
                                 autoComplete="off"
@@ -400,8 +473,8 @@ export default function CartModal({ cart }: { cart: Cart | undefined }) {
                     {isCheckoutDisabled
                       ? 'Please Enter All Child Names'
                       : isSavingNotes
-                        ? 'Saving...' 
-                        : 'Proceed to Checkout'}
+                      ? 'Saving...'
+                      : 'Proceed to Checkout'}
                   </button>
                 </div>
               )}

--- a/types/gtag.d.ts
+++ b/types/gtag.d.ts
@@ -1,0 +1,5 @@
+type GtagEventParams = Record<string, string | number | boolean | undefined>;
+
+interface Window {
+  gtag?: (command: 'event', eventName: string, params?: GtagEventParams) => void;
+}


### PR DESCRIPTION
## What changed

- Redesigns the school landing page around a shorter parent ordering flow.
- Uses `isFulfilledBySchoolKits` from Core to show a fulfilled-by-School-Kits trust signal.
- Removes the TEFA banner and cookie banner from the main commerce layout.
- Adds GA4 `add_to_cart` and storefront-side `begin_checkout` tracking with ecommerce item data before redirecting to Shopify checkout.
- Adds a small web vitals reporter and global `window.gtag` type.

## Why

The Neill school page was too bare and too repetitive once we added trust copy. On mobile, parents had to scroll through too much explanation before seeing grade kits. The revised page gets to the grade cards faster and uses plainer copy.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec prettier --check app/layout.tsx 'app/schools/[slug]/page.tsx'`
- Mobile screenshot at 390px showed the first kit card in the initial viewport after removing the cookie banner.

## Notes

`pnpm test` still hits the existing ESLint config issue in this repo, so I used TypeScript and targeted Prettier checks for this PR.