### PR TITLE
Fix unavailable school page copy

### DIFF
--- a/app/schools/[slug]/page.tsx
+++ b/app/schools/[slug]/page.tsx
@@ -49,12 +49,15 @@ export default async function SchoolDetailPage({ params }: SchoolPageParams) {
     new Set(source.flatMap((item) => (item.shopifyProductId ? [item.shopifyProductId] : [])))
   );
   const products = productIds.length > 0 ? await getProductsByIds(productIds) : [];
+  const hasProducts = products.length > 0;
   const location = [school.city, school.state].filter(Boolean).join(', ');
   const isOfficialSchoolKit = school.isFulfilledBySchoolKits;
   const heroTitle = `${school.name} kits`;
-  const heroDescription = isOfficialSchoolKit
-    ? `We use ${school.name}'s official supply lists, then pack each grade as one kit. Pick your child's grade below.`
-    : `Pick an available grade kit below. You can review the supplies before adding it to your cart.`;
+  const heroDescription = hasProducts
+    ? isOfficialSchoolKit
+      ? `We use ${school.name}'s official supply lists, then pack each grade as one kit. Pick your child's grade below.`
+      : `Pick an available grade kit below. You can review the supplies before adding it to your cart.`
+    : `Kits for this school are not available to order online yet. Send a quick request and we'll review this school.`;
 
   return (
     <div className="bg-white">
@@ -69,8 +72,8 @@ export default async function SchoolDetailPage({ params }: SchoolPageParams) {
 
       <section className="border-y border-[#D9EEF4] bg-[#F4FDFF]">
         <div className="mx-auto grid max-w-6xl gap-5 px-4 py-5 sm:px-6 sm:py-6 lg:grid-cols-[1.05fr_0.95fr] lg:items-start lg:px-8 lg:py-8">
-          <div>
-            <div className="space-y-3 sm:flex sm:items-start sm:gap-4 sm:space-y-0">
+          <div className="max-w-3xl">
+            <div className="space-y-3">
               <div className="flex items-center gap-3">
                 {school.logoUrl ? (
                   <div className="flex h-16 w-16 shrink-0 items-center justify-center rounded-lg border border-[#D9EEF4] bg-white p-2 shadow-sm sm:h-16 sm:w-16">
@@ -104,7 +107,7 @@ export default async function SchoolDetailPage({ params }: SchoolPageParams) {
             </p>
           </div>
 
-          {products.length > 0 ? (
+          {hasProducts ? (
             <div className="hidden self-start rounded-lg border border-[#B8DDE7] bg-white p-4 shadow-sm sm:p-5 md:block">
               <p className="text-sm font-bold uppercase text-[#0B80A7]">Ordering note</p>
               <h2 className="mt-1.5 text-xl font-bold text-black sm:text-2xl">
@@ -129,14 +132,18 @@ export default async function SchoolDetailPage({ params }: SchoolPageParams) {
         <section id="grade-kits">
           <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
             <div>
-              <h2 className="text-2xl font-bold text-black">Choose a grade</h2>
+              <h2 className="text-2xl font-bold text-black">
+                {hasProducts ? 'Choose a grade' : 'Request this school'}
+              </h2>
               <p className="mt-1 text-sm leading-6 text-gray-600">
-                Tap a kit to see the supplies and order.
+                {hasProducts
+                  ? 'Tap a kit to see the supplies and order.'
+                  : 'Tell us who you are and we will send this request to our team.'}
               </p>
             </div>
           </div>
 
-          {products.length > 0 ? (
+          {hasProducts ? (
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {products.map((product) => {
                 const price = product.priceRange.minVariantPrice.amount;


### PR DESCRIPTION
## Summary
- gate school page order/request copy on whether products are actually available
- show request/review copy for schools with no online kits instead of “choose a grade” ordering copy
- keep the school hero aligned as one column so logo/status/title content does not feel fragmented

## Verification
- git diff --check origin/main..codex/school-unavailable-copy