### PR TITLE
Redirect undefined path

### DIFF
--- a/app/undefined/page.tsx
+++ b/app/undefined/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function UndefinedPathRedirect() {
+  redirect('/schools');
+}


### PR DESCRIPTION
## Summary
- Add an exact `/undefined` route that redirects to `/schools`
- Prevent stale or malformed `/undefined` hits from rendering the Shopify page fallback 404 and recording GA page views for that path

## Verification
- `pnpm exec prettier --check app/undefined/page.tsx`
- `pnpm exec next typegen`
- `pnpm exec tsc --noEmit`
- `git diff --check`