### PR TITLE
Fix TEFA banner layout import

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import { GoogleAnalytics } from '@next/third-parties/google';
 import Footer from 'components/layout/footer';
 import Navbar from 'components/layout/navbar';
+import TefaSchoolBanner from 'components/layout/tefa-school-banner';
 import { ensureStartsWith } from 'lib/utils';
 import type { Metadata } from 'next';
 import { Open_Sans } from 'next/font/google';


### PR DESCRIPTION
## Summary

- Add the missing `TefaSchoolBanner` import in `app/layout.tsx`.
- Fixes the Vercel TypeScript build error from main where `<TefaSchoolBanner />` was rendered without being imported.

## Validation

- `git diff --check` passed.
- A temp-worktree `pnpm exec tsc --noEmit` no longer reports the `Cannot find name 'TefaSchoolBanner'` error; it is blocked only by the temp worktree missing untracked `next-env.d.ts`, which causes unrelated static image module declaration errors.

Vercel should now move past the reported layout import failure.