### PR TITLE
Add TEFA Finder search CTA

### DIFF
--- a/app/tefa-parents/page.tsx
+++ b/app/tefa-parents/page.tsx
@@ -11,6 +11,7 @@ import tefaFinderScreenshot from '../../media/tefa-finder-school-kits-supply.png
 const title = 'TEFA Parent Ordering Help';
 const description =
   'How parents can find School Kits Supply for TEFA school supply orders by searching School Kits and filtering by Supplies in TEFA Finder or Odyssey.';
+const tefaFinderSearchUrl = 'https://finder.educationfreedom.texas.gov/?q=school+kits&t=supplies';
 
 export const metadata: Metadata = {
   title,
@@ -80,8 +81,17 @@ export default function TefaParentsPage() {
 
             <div className="mt-8 flex flex-col gap-3 sm:flex-row">
               <Link
-                href="#questions"
+                href={tefaFinderSearchUrl}
+                target="_blank"
+                rel="noopener noreferrer"
                 className="inline-flex items-center justify-center rounded-full bg-[#0B80A7] px-6 py-3 text-sm font-bold text-white transition hover:bg-[#096c8c]"
+              >
+                Open TEFA Finder search
+                <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />
+              </Link>
+              <Link
+                href="#questions"
+                className="inline-flex items-center justify-center rounded-full border border-[#B7E5F2] bg-white px-6 py-3 text-sm font-bold text-[#0B80A7] transition hover:bg-[#EAF8FC]"
               >
                 Ask a question
                 <ArrowRight className="ml-2 h-4 w-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary

- Add an `Open TEFA Finder search` CTA beside `Ask a question` on `/tefa-parents`.
- Use the TEFA Finder search URL captured from the screenshot: `https://finder.educationfreedom.texas.gov/?q=school+kits&t=supplies`.
- Open the external link in a new tab with `noopener noreferrer`.

## Validation

- `pnpm exec prettier --write app/tefa-parents/page.tsx`
- `pnpm exec tsc --noEmit`
- Browser check on a mobile viewport confirmed the CTA is visible and has the expected `href`, `target`, and `rel` attributes.