### PR TITLE
Honor Shopify collection ordering

### DIFF
--- a/app/collection/[collection]/page.tsx
+++ b/app/collection/[collection]/page.tsx
@@ -4,7 +4,6 @@ import Image from 'next/image';
 import { notFound } from 'next/navigation';
 
 import ProductGridItems from 'components/layout/product-grid-items';
-import { defaultSort, sorting } from 'lib/constants';
 
 //export const runtime = 'edge';
 
@@ -26,66 +25,31 @@ export async function generateMetadata({
 }
 
 export default async function CategoryPage({
-  params,
-  searchParams
+  params
 }: {
   params: Promise<{ collection: string }>;
-  searchParams?: Promise<{ [key: string]: string | string[] | undefined }>;
 }) {
   const { collection: collectionHandle } = await params;
-  const resolvedSearchParams = searchParams ? await searchParams : {};
-  const { sort } = resolvedSearchParams as { [key: string]: string };
-  const { sortKey, reverse } = sorting.find((item) => item.slug === sort) || defaultSort;
-  
+
   const collection = await getCollection(collectionHandle);
-  let products = await getCollectionProducts({ collection: collectionHandle, sortKey, reverse });
-  
+  const products = await getCollectionProducts({
+    collection: collectionHandle,
+    sortKey: 'COLLECTION_DEFAULT'
+  });
+
   if (!collection) return notFound();
-
-  // Define the desired grade order.
-  const gradeOrder = [
-    'pre-k',
-    'kindergarten',
-    'first',
-    'second',
-    'third',
-    'fourth',
-    'fifth',
-    'sixth',
-    'seventh',
-    'eighth',
-    'ninth',
-    'tenth',
-    'eleventh',
-    'twelfth'
-  ];
-
-  // Helper function to determine the grade index from the product handle.
-  function getGradeIndex(product: any) {
-    const handle = product.handle.toLowerCase();
-    for (let i = 0; i < gradeOrder.length; i++) {
-      if (handle.includes(gradeOrder[i])) {
-        return i;
-      }
-    }
-    // If no grade is found, return a value that pushes it to the end.
-    return gradeOrder.length;
-  }
-
-  // Sort products based on the grade order.
-  products = products.sort((a, b) => getGradeIndex(a) - getGradeIndex(b));
 
   return (
     <section className="container mx-auto px-4 py-8">
-      <div className="bg-gradient-to-r from-blue-100 to-purple-100 rounded-lg shadow-md overflow-hidden">
-        <div className="flex flex-col md:flex-row items-center justify-between p-6 md:p-8">
-          <div className="flex items-center mb-4 md:mb-0">
+      <div className="overflow-hidden rounded-lg bg-gradient-to-r from-blue-100 to-purple-100 shadow-md">
+        <div className="flex flex-col items-center justify-between p-6 md:flex-row md:p-8">
+          <div className="mb-4 flex items-center md:mb-0">
             <div>
-              <h1 className="text-3xl md:text-4xl font-bold text-gray-800 mb-2">
+              <h1 className="mb-2 text-3xl font-bold text-gray-800 md:text-4xl">
                 {collection.title}
               </h1>
               {collection.description && (
-                <p className="text-sm md:text-base text-gray-600 max-w-md">
+                <p className="max-w-md text-sm text-gray-600 md:text-base">
                   {collection.description}
                 </p>
               )}
@@ -93,7 +57,7 @@ export default async function CategoryPage({
           </div>
           <div className="mt-4 md:mt-0">
             {collection.image ? (
-              <div className="w-24 h-24 md:w-32 md:h-32 mr-6 relative overflow-hidden rounded-full border-4 border-white shadow-lg">
+              <div className="relative mr-6 h-24 w-24 overflow-hidden rounded-full border-4 border-white shadow-lg md:h-32 md:w-32">
                 <Image
                   src={collection.image.src}
                   alt={collection.title}
@@ -103,17 +67,17 @@ export default async function CategoryPage({
                 />
               </div>
             ) : (
-              <div className="w-24 h-24 md:w-32 md:h-32 mr-6 bg-gray-200 rounded-full flex items-center justify-center border-4 border-white shadow-lg">
-                <span className="text-gray-500 text-xl">No Image</span>
+              <div className="mr-6 flex h-24 w-24 items-center justify-center rounded-full border-4 border-white bg-gray-200 shadow-lg md:h-32 md:w-32">
+                <span className="text-xl text-gray-500">No Image</span>
               </div>
             )}
           </div>
         </div>
       </div>
-      
+
       <div className="mt-8">
         {products.length === 0 ? (
-          <p className="py-3 text-lg text-center">{`No products found in this collection`}</p>
+          <p className="py-3 text-center text-lg">{`No products found in this collection`}</p>
         ) : (
           <ProductGridItems products={products} />
         )}


### PR DESCRIPTION
## What changed

- removed the collection page's unconditional client-side grade sorter
- request Shopify's `COLLECTION_DEFAULT` product order explicitly
- preserve Shopify's storefront visibility behavior, so archived, draft, and unpublished products remain excluded

## Why

The storefront was overwriting Shopify's collection order with a local handle-based grade sort. Titles such as Toddler and Pre-School were not recognized and were pushed to the end of the Iman Academy SW page.

Shopify documents `COLLECTION_DEFAULT` as the collection's configured default/manual order. Using it makes Shopify the source of truth for every collection page. Shopify always returns an ordered connection; grade ordering can remain the merchant-configured fallback in Shopify when a collection has not been manually rearranged.

## Validation

- Shopify Storefront GraphQL query validated against the current schema
- Prettier check passes for the changed file
- `git diff --check` passes
- repository-wide ESLint currently fails before checking files because of an existing circular configuration error in `.eslintrc.js`
- repository-wide TypeScript currently reports existing missing image-module declarations outside this change